### PR TITLE
chore: add Claude Code skill definitions

### DIFF
--- a/.claude/skills/commit-to-branch/SKILL.md
+++ b/.claude/skills/commit-to-branch/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: commit-to-branch
+description: Commit current changes to a branch. By default, commit to the branch we are currently at. If the branch is main, return a warning "DO NOT COMMIT TO MAIN." You should commit to a new branch if the command is "commit-to-branch new"
+---
+When committing code to the current branch, make sure:
+1. Have detailed but concise commit message
+
+When committing code to a new branch, make sure:
+1. Choose proper branch name
+2. Have detailed but concise commit message

--- a/.claude/skills/explain-code/SKILL.md
+++ b/.claude/skills/explain-code/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: explain-code
+description: Explains code with visual diagrams and analogies. Use when explaining how code works, teaching about a codebase, or when the user asks "how does this work?"
+---
+
+When explaining code, always include:
+
+1. **Start with an analogy**: Compare the code to something from everyday life
+2. **Draw a diagram**: Use ASCII art to show the flow, structure, or relationships
+3. **Walk through the code**: Explain step-by-step what happens
+4. **Highlight a gotcha**: What's a common mistake or misconception?
+
+Keep explanations conversational. For complex concepts, use multiple analogies.

--- a/.claude/skills/explain-skill/SKILL.md
+++ b/.claude/skills/explain-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: explain-skill
+description: Explains a specific customized skill.
+disable-model-invocation: true
+---
+
+When explaining skill, follow this order:
+
+1. name
+2. description
+3. other details


### PR DESCRIPTION
Add SKILL.md files for three reusable Claude Code skills:
- commit-to-branch: commit to current or new branch with conventional messages
- explain-code: explain code with visual diagrams and analogies
- explain-skill: document and explain other skills