### PR TITLE
docs: update CLAUDE.md and PRD.md to reflect Next.js migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,16 @@ ChronicPal helps patients undergoing recurring therapies (e.g., gout infusion tr
 
 | Layer | Choice |
 |-------|--------|
-| Frontend | React 18 + TypeScript, Vite, Tailwind CSS, Recharts, React Router v6 — Vercel |
-| Backend | Node.js 20, Express.js + TypeScript, Prisma ORM, PostgreSQL via Supabase — Railway |
-| Auth | JWT (access 15min / refresh 7d), bcrypt, httpOnly cookies |
-| AI | Anthropic Claude API (`claude-sonnet-4-20250514`) — backend only |
-| Testing | Vitest + React Testing Library + Playwright; coverage ≥ 80% |
-| Tooling | ESLint, Prettier (2-space, single quotes, trailing commas), Husky + lint-staged, npm |
+| Framework | Next.js 15 (App Router), React 19, TypeScript 5 — Vercel |
+| Styling | Tailwind CSS 4, PostCSS |
+| Auth | NextAuth v5 (Credentials provider, JWT session), bcryptjs, Zod validation |
+| Database | PostgreSQL (Supabase), Prisma ORM 6 |
+| AI | Anthropic Claude API (`claude-sonnet-4-5`) — server-side only (Route Handlers / Server Actions) |
+| Logging | Winston 3 (structured, PHI-safe allowlist) |
+| Testing | Vitest 3 + React Testing Library + Playwright; coverage ≥ 70% |
+| Tooling | ESLint, Prettier (2-space, single quotes, trailing commas), npm |
 
-Two separate repos: `ChronicPal-frontend` and `ChronicPal-backend`.
+**Monorepo layout** (`/chronicpal` is the primary app; `/ChronicPal-backend` and `/ChronicPal-frontend` are legacy and kept for reference only).
 
 ---
 
@@ -41,17 +43,16 @@ Two separate repos: `ChronicPal-frontend` and `ChronicPal-backend`.
 
 ## Common Commands
 
-```bash
-# Frontend
-npm run dev          # start Vite dev server
-npm run build        # production build
-npm run test         # Vitest
-npm run lint         # ESLint
+All commands run from the `/chronicpal` directory.
 
-# Backend
-npm run dev          # ts-node-dev watch
-npm run build        # tsc
-npm run test         # Vitest
+```bash
+npm run dev               # Next.js dev server (localhost:3000)
+npm run build             # production build (tsc + next build)
+npm run test              # Vitest unit/integration
+npm run test:e2e          # Playwright E2E
+npm run lint              # ESLint
+npm run typecheck         # tsc --noEmit
+
 npx prisma migrate dev    # apply migrations (dev)
 npx prisma generate       # regenerate client after schema change
 npx prisma studio         # GUI for DB inspection
@@ -59,13 +60,15 @@ npx prisma studio         # GUI for DB inspection
 
 ---
 
-## Backend Patterns
+## Architecture Patterns (Next.js App Router)
 
-- Route handlers are thin — delegate to service layer
-- All async routes wrapped with `asyncHandler`
-- Validate all input with Zod in `src/middleware/validators/`
+- **Route Handlers** live in `chronicpal/app/api/**` — keep them thin, delegate to `services/`
+- **Server Actions** for form mutations; Route Handlers for REST endpoints consumed by client components
+- Validate all input with Zod schemas in `chronicpal/validators/`
 - Response shape: `{ success: boolean, data?: T, error?: string }`
-- Keep AI prompts in `src/services/prompts/`
+- Keep AI prompts in `chronicpal/services/prompts/`
+- Auth guard via `chronicpal/lib/routeAuth.ts` — wrap every protected Route Handler
+- Prisma client singleton in `chronicpal/lib/prisma.ts` — never instantiate elsewhere
 - Run `npx prisma generate` after every schema change
 
 ---
@@ -83,7 +86,8 @@ npx prisma studio         # GUI for DB inspection
 - **NEVER** use Supabase client SDK — all DB access goes through Prisma
 
 ### Auth (ADR-3)
-- **NEVER** store JWT tokens in localStorage — httpOnly cookies only
+- **NEVER** store session tokens in localStorage — NextAuth manages httpOnly cookies
+- Use `auth()` from `chronicpal/auth.ts` for session checks in Server Components / Route Handlers
 
 ### Other
 - **NEVER** commit `.env` — only `.env.example` with placeholders

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -60,29 +60,42 @@ A clinician or pharmacist who wants a concise, data-driven patient summary befor
 - **Privacy**: Users own their data; data export available; no third-party data sharing
 - **Reliability**: 99.5% uptime target for API
 
+## Architecture
+
+| Concern | Decision |
+|---------|----------|
+| Framework | Next.js 15 — App Router (single monorepo, no separate backend service) |
+| Auth | NextAuth v5 (Credentials provider, JWT session) |
+| Database | PostgreSQL via Supabase, accessed exclusively through Prisma ORM |
+| Deployment | Vercel — preview deploys on PR, production deploy on merge to main |
+
 ## API Design Summary
+
+All endpoints are Next.js Route Handlers under `app/api/`.
 
 ### REST Endpoints
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | /api/auth/register | User registration |
-| POST | /api/auth/login | User login (JWT) |
-| GET | /api/treatments | List treatment entries |
+| POST | /api/auth/[...nextauth] | NextAuth sign-in / sign-out / session |
+| GET | /api/treatments | List treatment entries (auth required) |
 | POST | /api/treatments | Create treatment entry |
-| PUT | /api/treatments/:id | Update treatment entry |
-| DELETE | /api/treatments/:id | Delete treatment entry |
+| PUT | /api/treatments/[id] | Update treatment entry |
+| DELETE | /api/treatments/[id] | Delete treatment entry |
 | GET | /api/labs | List lab results |
 | POST | /api/labs | Log lab result |
+| GET | /api/symptoms | List symptom entries |
+| POST | /api/symptoms | Log symptom entry |
+| DELETE | /api/symptoms/[id] | Delete symptom entry |
 | GET | /api/diet | List diet entries |
 | POST | /api/diet | Log meal with AI analysis |
-| POST | /api/diet/analyze-image | Analyze meal image |
-| GET | /api/summary/pre-visit | Generate pre-visit summary |
+| POST | /api/diet/analyze-image | Analyze meal image (Claude vision) |
+| GET | /api/summary | Generate pre-visit summary |
 | POST | /api/share | Generate caregiver share link |
-| GET | /api/share/:token | Access shared dashboard |
-| GET | /api/trends/:metric | Get trend data for charts |
+| GET | /api/share/[token] | Access shared dashboard (no auth) |
 
 ### AI Integration Points
-- `POST /api/diet` — purine risk scoring via Claude API
+All Claude API calls are server-side only (Route Handlers / Server Actions):
+- `POST /api/diet` — purine risk scoring
 - `POST /api/diet/analyze-image` — meal image analysis via Claude vision
-- `GET /api/summary/pre-visit` — narrative summary generation via Claude API
-- `GET /api/trends/predict` — flare-up risk prediction (future)
+- `GET /api/summary` — narrative pre-visit summary generation

--- a/docs/Requirement.md
+++ b/docs/Requirement.md
@@ -1,0 +1,116 @@
+# Project Requirement
+
+## Objective
+Build a production-grade, deployed application as a pair, demonstrating mastery of Claude Code's extensibility features, professional AI-assisted workflows, and production engineering practices.
+
+
+
+## Requirements
+### Functional Requirements
+Production-ready application solving a real problem
+2+ user roles or distinct feature areas
+Real-world use case (new idea)
+Portfolio/interview-worthy quality
+Deployed and accessible via public URL
+
+### Technical Requirements
+#### Architecture
+1. Next.js full-stack application (App Router or Pages Router)
+2. Database (PostgreSQL recommended, or equivalent)
+3. Authentication (Auth.js/NextAuth, Clerk, or equivalent)
+4. Deployed on Vercel (or equivalent platform with preview deploys)
+
+#### Claude Code Mastery (core of this project)
+
+Each of the following Claude Code concepts must be demonstrated with evidence in your repository:
+
+- CLAUDE.md & Memory:
+	- Comprehensive CLAUDE.md with @imports for modular organization
+	- Auto-memory usage for persistent project context
+	- Evidence of CLAUDE.md evolution across the project (visible in git history)
+	- Project conventions, architecture decisions, and testing strategy documented
+
+- Custom Skills — minimum 2:
+	- At least 2 skills in .claude/skills/ (e.g., /fix-issue, /add-feature, /deploy, /create-pr)
+	- Evidence of team usage (session logs or screenshots)
+	- At least one skill iterated from v1 to v2 based on real usage
+
+- Hooks — minimum 2:
+	- At least 2 hooks configured in .claude/settings.json
+	- At least one PreToolUse or PostToolUse hook (e.g., auto-format, block protected files, lint-on-edit)
+	- At least one quality-enforcement hook (e.g., Stop hook that runs tests)
+
+- MCP Servers — minimum 1:
+	- At least 1 MCP server integrated (database, Playwright, GitHub, or other)
+	- Configuration shared via .mcp.json in repository
+	- Evidence of use in development workflow (session logs or screenshots)
+
+- Agents — minimum 1 (choose any):
+	- Custom sub-agents in .claude/agents/ (e.g., security-reviewer, test-writer), OR
+	- Agent teams with CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1, OR
+	- Agent SDK feature built into the application (applying W13 patterns)
+	- Evidence of use (session log, PR, or screenshots showing agent output)
+
+- Parallel Development:
+	- Evidence of worktree usage for parallel feature development
+	- At least 2 features developed in parallel (visible in git branch history)
+
+- Writer/Reviewer Pattern + C.L.E.A.R.:
+	- At least 2 PRs using the writer/reviewer pattern (one agent writes, another reviews)
+	- C.L.E.A.R. framework applied in PR reviews (visible in PR comments)
+	- AI disclosure metadata in PRs (% AI-generated, tool used, human review applied)
+
+- Test-Driven Development
+	- TDD workflow (red-green-refactor) for at least 3 features
+	- Git history showing failing tests committed before implementation
+	- Unit + integration tests (Vitest or Jest)
+	- At least 1 E2E test (Playwright)
+	- 70%+ test coverage
+
+- CI/CD Pipeline — GitHub Actions
+	- Lint (ESLint + Prettier)
+	- Type checking (tsc --noEmit)
+	- Unit and integration tests
+	- E2E tests (Playwright)
+	- Security scan (npm audit)
+	- AI PR review (claude-code-action or claude -p)
+	- Preview deploy (Vercel)
+	- Production deploy on merge to main
+
+- Security — minimum 4 gates from the 8-gate pipeline
+	- Pre-commit secrets detection (Gitleaks or equivalent)
+	- Dependency scanning (npm audit in CI)
+	- At least one SAST tool or security-focused sub-agent
+	- Security acceptance criteria in Definition of Done
+	- OWASP top 10 awareness documented in CLAUDE.md
+
+- Team Process
+	- 2 sprints documented (sprint planning + retrospective each)
+	- GitHub Issues with acceptance criteria as testable specifications
+	- Branch-per-issue workflow with PR reviews
+	- Async standups (minimum 3 per sprint per partner)
+	- C.L.E.A.R. framework applied in PR reviews
+	- Peer evaluations
+
+
+
+## Deliverables
+1. GitHub repository with full .claude/ configuration (skills, hooks, agents, MCP)
+2. Deployed application (Vercel production URL)
+3. CI/CD pipeline (GitHub Actions, all stages passing)
+4. Technical blog post (published on Medium, dev.to, or similar)
+5. Video demonstration (5-10 min, showcasing app + Claude Code workflow)
+6. Individual reflections (one per partner, 500 words)
+7. Showcase submission via Google FormLinks to an external site. (project name, URLs, thumbnail, video, blog)
+
+
+
+## Rubric
+|Criteria|Rating|
+|---|---|
+|Application Quality|Excellent - Production-ready, deployed on Vercel, polished UI, 2+ user roles, real problem solved, portfolio-worthy|
+|Claude Code Mastery|Excellent - Rich CLAUDE.md with @imports and git evolution; 2+ iterated skills with usage evidence; 2+ hooks enforcing quality; MCP server integrated via .mcp.json; agents (sub-agents/teams/SDK) with evidence; parallel worktree development; 2+ PRs with writer/reviewer + C.L.E.A.R. + AI disclosure|
+|Testing & TDD|Excellent - TDD red-green-refactor for 3+ features visible in git; 70%+ coverage; unit + integration + E2E (Playwright); tests verify behavior and edge cases|
+|CI/CD & Production|Excellent - All 8 pipeline stages green (lint, typecheck, tests, E2E, security, AI review, preview, prod deploy); 4+ security gates; OWASP in CLAUDE.md|
+|Team Process|Excellent - 2 sprints with planning + retrospectives; branch-per-issue with PR reviews; 3+ async standups/sprint/partner; C.L.E.A.R. in reviews; AI disclosure; thoughtful peer evaluation|
+|Documentation & Demo|Excellent - Clear README with Mermaid architecture diagram; published blog post with AI workflow insights; polished 5-10 min video demo showcasing app + Claude Code workflow; 500-word reflections with specific Claude Code insights|


### PR DESCRIPTION
- CLAUDE.md: replace React/Vite + Express stack with Next.js 15 (App Router), NextAuth v5, Prisma 6, React 19, Tailwind CSS 4; consolidate commands to /chronicpal directory; rewrite Backend Patterns as Architecture Patterns for App Router; update Auth rule to use NextAuth auth() helper; document monorepo layout
- docs/PRD.md: add Architecture table (Next.js 15, NextAuth v5, Prisma/Supabase, Vercel); update API endpoint paths to Next.js dynamic segment syntax ([id], [...nextauth]); add /api/symptoms routes; clarify AI calls are server-side only
- docs/Requirement.md: add project requirement reference doc